### PR TITLE
Include views (html) in watch task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -40,6 +40,14 @@ module.exports = function(grunt) {
         options: {
           spawn: false
         }
+      },
+
+      html: {
+        files: ['app/views/**/*.html'],
+        tasks: ['copy:views'],
+        options: {
+          spawn: false
+        }
       }
     },
 


### PR DESCRIPTION
Makes `grunt watch` trigger on changes to Views also.

Might make sense to have a target for the `package.manifest` file also?  Any others?
