### PR TITLE
Default Dependencies

### DIFF
--- a/app/templates/app/scripts/controllers/name.controller.js
+++ b/app/templates/app/scripts/controllers/name.controller.js
@@ -1,4 +1,4 @@
-angular.module('umbraco').controller('<%= names.ctrl %>', function() {
+angular.module('umbraco').controller('<%= names.ctrl %>', function($scope) {
   console.log('Hello from <%= names.ctrl %>');
 });
 


### PR DESCRIPTION
Adds `$scope` as a dependency in the controller template

We probably shouldn't have too many (if any more at all) dependencies by default, but I figured `$scope` was pretty important as its needed to save data back to Umbraco, so I would think the majority will want it.
