### PR TITLE
WIP - Make 'dist' path configurable via option

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-    dest: grunt.option('target') ? grunt.option('target') : 'dist',
+    dest: grunt.option('target') || 'dist',
     basePath: 'App_Plugins/<%%= pkg.name %>',
 
     concat: {


### PR DESCRIPTION
This mimics the `grunt watch:dev --target="D:\MySite"` option from Archetype, but with a simpler approach (thanks @taylorsmith)

Instead of adding new tasks, we're making the `/dist/` directory configurable, so existing tasks can be used easily (ie, `grunt` or `grunt watch`)

Examples:

`grunt --target="D:\MySite"`

`grunt watch --target="D:\MySite"`

Note that we're now building using the full folder structure (`App_Plugins/<name>/<files>`) instead of a flat structure, which should make deployment a bit easier, especially when we add other folders like `/bin/`

Implements #6 
