### PR TITLE
Condense the validation of --target

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -4,6 +4,9 @@ module.exports = function(grunt) {
   // Add in time grunt
   require('time-grunt')(grunt);
 
+  if (grunt.option('target') && !grunt.file.isDir(grunt.option('target')))
+    grunt.fail.warn('The --target option specified is not a valid directory');
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     dest: grunt.option('target') || 'dist',
@@ -136,57 +139,8 @@ module.exports = function(grunt) {
     }
   });
 
-  //Legacy - now below so we can run our validation check first...
-  //grunt.registerTask('default', ['concat', 'less', 'copy:config', 'copy:views']);
-  //grunt.registerTask('nuget', ['clean', 'default', 'copy:nuget', 'template:nuspec', 'mkdir:pkg', 'nugetpack']);
-  //grunt.registerTask('package', ['clean', 'default', 'copy:umbraco', 'mkdir:pkg', 'umbracoPackage']);
-
-  //TASK: default
-  grunt.registerTask('default', 'Concat files, build Less & copy config & views', function(){
-    validateTarget();
-    grunt.task.run(['concat', 'less', 'copy:config', 'copy:views']);
-  });
-
-  //TASK nuget
-  grunt.registerTask('nuget', 'Clean, rebuild, copy files for nuget & create it', function(){
-    validateTarget();
-    grunt.task.run(['clean', 'default', 'copy:nuget', 'template:nuspec', 'mkdir:pkg', 'nugetpack']);
-  });
-
-
-  //TASK umbraco
-  grunt.registerTask('package', 'Clean, rebuild, copy files for umbraco package & create it', function(){
-    validateTarget();
-    grunt.task.run(['clean', 'default', 'copy:umbraco', 'mkdir:pkg', 'umbracoPackage']);
-  });
-
-
-  
-  //Validation for --target option
-  function validateTarget() {
-
-    var destTarget = grunt.config.get('dest');
-
-    //Debug
-    grunt.log.oklns('Target (dest) is: ' + destTarget);
-
-    //If dest is not set to dist then a target option was set
-    if(destTarget != 'dist') {
-
-      //Happens when grunt --target is called
-      if(destTarget === true) {
-        //Error message & stop processing task
-        grunt.fail.warn('You need to specify a folder for target: grunt --target=c:/mysite/');
-      }
-
-      //Ensure that the dest value the --target is actually a directory that exists
-      if(!grunt.file.isDir(destTarget)){
-
-        //Error message & stop processing task
-        grunt.fail.warn('The target passed in is not a folder path.');
-      }
-    }
-  }
+  grunt.registerTask('default', ['concat', 'less', 'copy:config', 'copy:views']);
+  grunt.registerTask('nuget', ['clean', 'default', 'copy:nuget', 'template:nuspec', 'mkdir:pkg', 'nugetpack']);
+  grunt.registerTask('package', ['clean', 'default', 'copy:umbraco', 'mkdir:pkg', 'umbracoPackage']);
 
 };
-


### PR DESCRIPTION
This refactors the code needed to validate that the `--target` passed, if any, is a valid folder.

Just a personal thing, was just bugged by way we had to declare our tasks now and all the additional code needed in the Gruntfile.  This seems a bit simpler and should achieve the same thing.
