### PR TITLE
Watch tweaks

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -1,7 +1,5 @@
 module.exports = function(grunt) {
   require('load-grunt-tasks')(grunt);
-
-  // Add in time grunt
   require('time-grunt')(grunt);
 
   grunt.initConfig({


### PR DESCRIPTION
Just a couple things we've found helpful:
- Running `grunt watch` will now kick off the watch tasks for you once, thus (usually) eliminating the need to run `grunt` by itself first
- Add `package.manifest` as a file to watch
